### PR TITLE
Implement Ogmios-like reflection mechanism in WS api

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,9 @@ Request:
   "methodname": "GetDatumByHash",
   "args": {
     "hash": "04caaf1336b754e0b8b4e2fa1c59aa6b85f97dd29652729f1c1e28805acdeb20"
-  }
+  },
+  // optional
+  "mirror": {"meta": "this object will be mirrored under 'reflection' field in a response to this request"}
 }
 ```
 
@@ -163,7 +165,8 @@ Response (datum found):
   result: { DatumFound: { value: [Object] } },
   version: '1.0',
   servicename: 'ogmios-datum-cache',
-  type: 'jsonwsp/response'
+  type: 'jsonwsp/response',
+  reflection: {"meta": "this object will be mirrored under 'reflection' field in a response to this request"}
 }
 ```
 
@@ -201,7 +204,8 @@ Response (datum found):
   },
   "version": "1.0",
   "servicename": "ogmios-datum-cache",
-  "type": "jsonwsp/response"
+  "type": "jsonwsp/response",
+  "reflection": {"meta": "this object will be mirrored under 'reflection' field in a response to this request"}
 }
 
 ```
@@ -213,7 +217,8 @@ Response (datum not found):
   result: { DatumNotFound: null },
   version: '1.0',
   servicename: 'ogmios-datum-cache',
-  type: 'jsonwsp/response'
+  type: 'jsonwsp/response',
+  reflection: {"meta": "this object will be mirrored under 'reflection' field in a response to this request"}
 }
 ```
 
@@ -224,7 +229,8 @@ Response (fault):
   version: '1.0',
   fault: { string: 'Error deserializing plutus Data', code: 'client' },
   servicename: 'ogmios-datum-cache',
-  type: 'jsonwsp/fault'
+  type: 'jsonwsp/fault',
+  reflection: {"meta": "this object will be mirrored under 'reflection' field in a response to this request"}
 }
 ```
 
@@ -243,7 +249,8 @@ Request:
       "abc",
       "04caaf1336b754e0b8b4e2fa1c59aa6b85f97dd29652729f1c1e28805acdeb20"
     ]
-  }
+  },
+  "mirror": "req.no.1"
 }
 ```
 
@@ -254,7 +261,8 @@ Response:
   result: { DatumsFound: { value: [Array] } },
   version: '1.0',
   servicename: 'ogmios-datum-cache',
-  type: 'jsonwsp/response'
+  type: 'jsonwsp/response',
+  reflection: "req.no.1"
 }
 ```
 
@@ -297,7 +305,8 @@ Response:
   },
   "version": "1.0",
   "servicename": "ogmios-datum-cache",
-  "type": "jsonwsp/response"
+  "type": "jsonwsp/response",
+  "reflection": "req.no.1"
 }
 ```
 
@@ -311,7 +320,8 @@ Response (fault)
     code: 'client'
   },
   servicename: 'ogmios-datum-cache',
-  type: 'jsonwsp/fault'
+  type: 'jsonwsp/fault',
+  reflection: "req.no.1"
 }
 ```
 #### StartFetchBlocks
@@ -325,7 +335,8 @@ Request:
   "args": {
     "slot": 1,
     "id": "abc"
-  }
+  },
+  "mirror": "foo"
 }
 ```
 
@@ -338,7 +349,8 @@ Response:
   },
   "version": "1.0",
   "servicename": "ogmios-datum-cache",
-  "type": "jsonwsp/response"
+  "type": "jsonwsp/response",
+  "reflection": "foo"
 }
 ```
 
@@ -352,7 +364,8 @@ Response (fault):
     "code": "client"
   },
   "servicename": "ogmios-datum-cache",
-  "type": "jsonwsp/fault"
+  "type": "jsonwsp/fault",
+  "reflection": "foo"
 }
 ```
 
@@ -363,7 +376,8 @@ Request:
   "type": "jsonwsp/request",
   "version": "1.0",
   "servicename": "ogmios-datum-cache",
-  "methodname": "CancelFetchBlocks"
+  "methodname": "CancelFetchBlocks",
+  "reflection": "foo"
 }
 ```
 
@@ -376,7 +390,8 @@ Response:
   },
   "version": "1.0",
   "servicename": "ogmios-datum-cache",
-  "type": "jsonwsp/response"
+  "type": "jsonwsp/response",
+  "reflection": "foo"
 }
 ```
 
@@ -390,7 +405,8 @@ Response (fault):
     "code": "client"
   },
   "servicename": "ogmios-datum-cache",
-  "type": "jsonwsp/fault"
+  "type": "jsonwsp/fault",
+  "reflection": "foo"
 }
 ```
 
@@ -407,7 +423,8 @@ Request:
       "abc",
       "04caaf1336b754e0b8b4e2fa1c59aa6b85f97dd29652729f1c1e28805acdeb20"
     ]
-  }
+  },
+  "mirror": "foo"
 }
 ```
 
@@ -420,7 +437,8 @@ Response:
   },
   "version": "1.0",
   "servicename": "ogmios-datum-cache",
-  "type": "jsonwsp/response"
+  "type": "jsonwsp/response",
+  "reflection": "foo"
 }
 ```
 
@@ -450,7 +468,8 @@ Response:
   },
   "version": "1.0",
   "servicename": "ogmios-datum-cache",
-  "type": "jsonwsp/response"
+  "type": "jsonwsp/response",
+  "reflection": null
 }
 ```
 
@@ -467,7 +486,7 @@ Request:
       "abc",
       "04caaf1336b754e0b8b4e2fa1c59aa6b85f97dd29652729f1c1e28805acdeb20"
     ]
-  }
+  },
 }
 ```
 
@@ -480,7 +499,8 @@ Response:
   },
   "version": "1.0",
   "servicename": "ogmios-datum-cache",
-  "type": "jsonwsp/response"
+  "type": "jsonwsp/response",
+  "reflection": null
 }
 ```
 
@@ -491,7 +511,8 @@ Request:
   "type": "jsonwsp/request",
   "version": "1.0",
   "servicename": "ogmios-datum-cache",
-  "methodname": "DatumFilterGetHashes"
+  "methodname": "DatumFilterGetHashes",
+  "mirror": "foo"
 }
 ```
 
@@ -507,7 +528,9 @@ Response:
   },
   "version": "1.0",
   "servicename": "ogmios-datum-cache",
-  "type": "jsonwsp/response"
+  "type": "jsonwsp/response",
+  "reflection": "foo"
+  
 }
 ```
 

--- a/src/Api/WebSocket.hs
+++ b/src/Api/WebSocket.hs
@@ -5,7 +5,7 @@ import Colog (logError, logInfo, logWarning)
 import Control.Monad (forever, void)
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad.Reader (ask, runReaderT)
-import Data.Aeson (Value(Null))
+import Data.Aeson (Value (Null))
 import Data.Aeson qualified as Json
 import Data.ByteString.Lazy qualified as BSL
 import Data.Either (fromLeft, fromRight, isLeft)
@@ -21,8 +21,8 @@ import UnliftIO.Exception (onException)
 import UnliftIO.MVar (isEmptyMVar, tryPutMVar, tryTakeMVar)
 
 import Api.WebSocket.Json (
-    JsonWspResponse,
     JsonWspFault,
+    JsonWspResponse,
     mkCancelFetchBlocksFault,
     mkCancelFetchBlocksResponse,
     mkDatumFilterAddHashesResponse,
@@ -39,7 +39,7 @@ import Api.WebSocket.Json (
 import Api.WebSocket.Types (
     GetDatumsByHashesDatum (..),
     JsonWspRequest (..),
-    Method(..)
+    Method (..),
  )
 import App (App (..))
 import App.Env (Env (..))
@@ -133,19 +133,19 @@ datumFilterAddHashes :: [Text] -> App (Either JsonWspFault JsonWspResponse)
 datumFilterAddHashes hashes = do
     Env{..} <- ask
     RequestedDatumHashes.add hashes envRequestedDatumHashes
-    pure $ Right $ mkDatumFilterAddHashesResponse
+    pure $ Right mkDatumFilterAddHashesResponse
 
 datumFilterRemoveHashes :: [Text] -> App (Either JsonWspFault JsonWspResponse)
 datumFilterRemoveHashes hashes = do
     Env{..} <- ask
     RequestedDatumHashes.remove hashes envRequestedDatumHashes
-    pure $ Right $ mkDatumFilterRemoveHashesResponse
+    pure $ Right mkDatumFilterRemoveHashesResponse
 
 datumFilterSetHashes :: [Text] -> App (Either JsonWspFault JsonWspResponse)
 datumFilterSetHashes hashes = do
     Env{..} <- ask
     RequestedDatumHashes.set hashes envRequestedDatumHashes
-    pure $ Right $ mkDatumFilterSetHashesResponse
+    pure $ Right mkDatumFilterSetHashesResponse
 
 datumFilterGetHashes :: App (Either JsonWspFault JsonWspResponse)
 datumFilterGetHashes = do
@@ -186,7 +186,7 @@ websocketServer conn = forever $ do
     receiveData = liftIO $ WS.receiveData conn
 
     appendJsonWspReflection = \case
-      (mirror, Json.Object jsonWspResponseObject) ->
-        Json.Object $ HM.insert "reflection" (fromMaybe Null mirror) jsonWspResponseObject
-      -- this should not be the case anyway
-      (_, nonObject) -> nonObject
+        (mirror, Json.Object jsonWspResponseObject) ->
+            Json.Object $ HM.insert "reflection" (fromMaybe Null mirror) jsonWspResponseObject
+        -- this should not be the case anyway
+        (_, nonObject) -> nonObject

--- a/src/Api/WebSocket/Json.hs
+++ b/src/Api/WebSocket/Json.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE DuplicateRecordFields #-}
 
 module Api.WebSocket.Json (
+    JsonWspResponse,
+    JsonWspFault,
     mkGetDatumByHashResponse,
     mkGetDatumByHashFault,
     mkGetDatumsByHashesResponse,

--- a/src/Api/WebSocket/Types.hs
+++ b/src/Api/WebSocket/Types.hs
@@ -1,10 +1,56 @@
-module Api.WebSocket.Types (Method (..), GetDatumsByHashesDatum (..)) where
+module Api.WebSocket.Types (JsonWspRequest(JsonWspRequest), Method (..), GetDatumsByHashesDatum (..)) where
 
-import Data.Aeson (FromJSON, ToJSON, parseJSON, withObject, (.:))
+import Data.Aeson (Value, FromJSON, ToJSON, parseJSON, withObject, (.:), (.:?))
 import Data.Text (Text)
 import GHC.Generics (Generic)
 
 import PlutusData qualified
+
+data JsonWspRequest = JsonWspRequest
+   { mirror :: Maybe Value
+   , method :: Method
+   }
+   deriving stock (Generic)
+
+instance FromJSON JsonWspRequest where
+  parseJSON = withObject "JsonWspRequest" $ \o ->
+    JsonWspRequest <$> (o .:? "mirror") <*> parseMethod o
+
+    where
+      parseMethod o = do
+          (method :: Text) <- o .: "methodname"
+          case method of
+              "GetDatumByHash" -> do
+                  args <- o .: "args"
+                  hash <- args .: "hash"
+                  pure $ GetDatumByHash hash
+              "GetDatumsByHashes" -> do
+                  args <- o .: "args"
+                  hashes <- args .: "hashes"
+                  pure $ GetDatumsByHashes hashes
+              "StartFetchBlocks" -> do
+                  args <- o .: "args"
+                  slot <- args .: "slot"
+                  blockId <- args .: "id"
+                  pure $ StartFetchBlocks slot blockId
+              "CancelFetchBlocks" -> do
+                  pure CancelFetchBlocks
+              "DatumFilterAddHashes" -> do
+                  args <- o .: "args"
+                  hashes <- args .: "hashes"
+                  pure $ DatumFilterAddHashes hashes
+              "DatumFilterRemoveHashes" -> do
+                  args <- o .: "args"
+                  hashes <- args .: "hashes"
+                  pure $ DatumFilterRemoveHashes hashes
+              "DatumFilterSetHashes" -> do
+                  args <- o .: "args"
+                  hashes <- args .: "hashes"
+                  pure $ DatumFilterSetHashes hashes
+              "DatumFilterGetHashes" -> do
+                  pure DatumFilterGetHashes
+              _ -> fail "Unexpected method"
+
 
 data Method
     = GetDatumByHash Text
@@ -16,41 +62,6 @@ data Method
     | DatumFilterSetHashes [Text]
     | DatumFilterGetHashes
     deriving stock (Show)
-
-instance FromJSON Method where
-    parseJSON = withObject "GetDatumByHash" $ \o -> do
-        (method :: Text) <- o .: "methodname"
-        case method of
-            "GetDatumByHash" -> do
-                args <- o .: "args"
-                hash <- args .: "hash"
-                pure $ GetDatumByHash hash
-            "GetDatumsByHashes" -> do
-                args <- o .: "args"
-                hashes <- args .: "hashes"
-                pure $ GetDatumsByHashes hashes
-            "StartFetchBlocks" -> do
-                args <- o .: "args"
-                slot <- args .: "slot"
-                blockId <- args .: "id"
-                pure $ StartFetchBlocks slot blockId
-            "CancelFetchBlocks" -> do
-                pure CancelFetchBlocks
-            "DatumFilterAddHashes" -> do
-                args <- o .: "args"
-                hashes <- args .: "hashes"
-                pure $ DatumFilterAddHashes hashes
-            "DatumFilterRemoveHashes" -> do
-                args <- o .: "args"
-                hashes <- args .: "hashes"
-                pure $ DatumFilterRemoveHashes hashes
-            "DatumFilterSetHashes" -> do
-                args <- o .: "args"
-                hashes <- args .: "hashes"
-                pure $ DatumFilterSetHashes hashes
-            "DatumFilterGetHashes" -> do
-                pure DatumFilterGetHashes
-            _ -> fail "Unexpected method"
 
 data GetDatumsByHashesDatum = GetDatumsByHashesDatum
     { hash :: Text

--- a/src/Api/WebSocket/Types.hs
+++ b/src/Api/WebSocket/Types.hs
@@ -1,56 +1,54 @@
-module Api.WebSocket.Types (JsonWspRequest(JsonWspRequest), Method (..), GetDatumsByHashesDatum (..)) where
+module Api.WebSocket.Types (JsonWspRequest (JsonWspRequest), Method (..), GetDatumsByHashesDatum (..)) where
 
-import Data.Aeson (Value, FromJSON, ToJSON, parseJSON, withObject, (.:), (.:?))
+import Data.Aeson (FromJSON, ToJSON, Value, parseJSON, withObject, (.:), (.:?))
 import Data.Text (Text)
 import GHC.Generics (Generic)
 
 import PlutusData qualified
 
 data JsonWspRequest = JsonWspRequest
-   { mirror :: Maybe Value
-   , method :: Method
-   }
-   deriving stock (Generic)
+    { mirror :: Maybe Value
+    , method :: Method
+    }
+    deriving stock (Generic)
 
 instance FromJSON JsonWspRequest where
-  parseJSON = withObject "JsonWspRequest" $ \o ->
-    JsonWspRequest <$> (o .:? "mirror") <*> parseMethod o
-
-    where
-      parseMethod o = do
-          (method :: Text) <- o .: "methodname"
-          case method of
-              "GetDatumByHash" -> do
-                  args <- o .: "args"
-                  hash <- args .: "hash"
-                  pure $ GetDatumByHash hash
-              "GetDatumsByHashes" -> do
-                  args <- o .: "args"
-                  hashes <- args .: "hashes"
-                  pure $ GetDatumsByHashes hashes
-              "StartFetchBlocks" -> do
-                  args <- o .: "args"
-                  slot <- args .: "slot"
-                  blockId <- args .: "id"
-                  pure $ StartFetchBlocks slot blockId
-              "CancelFetchBlocks" -> do
-                  pure CancelFetchBlocks
-              "DatumFilterAddHashes" -> do
-                  args <- o .: "args"
-                  hashes <- args .: "hashes"
-                  pure $ DatumFilterAddHashes hashes
-              "DatumFilterRemoveHashes" -> do
-                  args <- o .: "args"
-                  hashes <- args .: "hashes"
-                  pure $ DatumFilterRemoveHashes hashes
-              "DatumFilterSetHashes" -> do
-                  args <- o .: "args"
-                  hashes <- args .: "hashes"
-                  pure $ DatumFilterSetHashes hashes
-              "DatumFilterGetHashes" -> do
-                  pure DatumFilterGetHashes
-              _ -> fail "Unexpected method"
-
+    parseJSON = withObject "JsonWspRequest" $ \o ->
+        JsonWspRequest <$> (o .:? "mirror") <*> parseMethod o
+      where
+        parseMethod o = do
+            (method :: Text) <- o .: "methodname"
+            case method of
+                "GetDatumByHash" -> do
+                    args <- o .: "args"
+                    hash <- args .: "hash"
+                    pure $ GetDatumByHash hash
+                "GetDatumsByHashes" -> do
+                    args <- o .: "args"
+                    hashes <- args .: "hashes"
+                    pure $ GetDatumsByHashes hashes
+                "StartFetchBlocks" -> do
+                    args <- o .: "args"
+                    slot <- args .: "slot"
+                    blockId <- args .: "id"
+                    pure $ StartFetchBlocks slot blockId
+                "CancelFetchBlocks" -> do
+                    pure CancelFetchBlocks
+                "DatumFilterAddHashes" -> do
+                    args <- o .: "args"
+                    hashes <- args .: "hashes"
+                    pure $ DatumFilterAddHashes hashes
+                "DatumFilterRemoveHashes" -> do
+                    args <- o .: "args"
+                    hashes <- args .: "hashes"
+                    pure $ DatumFilterRemoveHashes hashes
+                "DatumFilterSetHashes" -> do
+                    args <- o .: "args"
+                    hashes <- args .: "hashes"
+                    pure $ DatumFilterSetHashes hashes
+                "DatumFilterGetHashes" -> do
+                    pure DatumFilterGetHashes
+                _ -> fail "Unexpected method"
 
 data Method
     = GetDatumByHash Text

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
 
 module Main (
     main,


### PR DESCRIPTION
Lack of a mechanism for mirroring user-provided data may force the cache user to depend on somewhat stack-specific websocket message ordering. This PR introduces the mechanism following Ogmios implementation.
