### PR TITLE
Fix WebSocket API docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ Response (datum found):
   "version": "1.0",
   "servicename": "ogmios-datum-cache",
   "type": "jsonwsp/response",
-  "reflection": {"meta": "this object will be mirrored under 'reflection' field in a response to this request"}
+  "reflection": "this string will be mirrored under 'reflection' field in a response to this request"
 }
 
 ```
@@ -205,7 +205,7 @@ Response (datum not found):
   version: '1.0',
   servicename: 'ogmios-datum-cache',
   type: 'jsonwsp/response',
-  reflection: {"meta": "this object will be mirrored under 'reflection' field in a response to this request"}
+  reflection: "this string will be mirrored under 'reflection' field in a response to this request"
 }
 ```
 
@@ -217,7 +217,7 @@ Response (fault):
   fault: { string: 'Error deserializing plutus Data', code: 'client' },
   servicename: 'ogmios-datum-cache',
   type: 'jsonwsp/fault',
-  reflection: {"meta": "this object will be mirrored under 'reflection' field in a response to this request"}
+  reflection: "this string will be mirrored under 'reflection' field in a response to this request"
 }
 ```
 


### PR DESCRIPTION
The documentation for WS API diverged from reality:

The readme suggests that `mirror` accepts arbitrary JSON
https://github.com/mlabs-haskell/ogmios-datum-cache#getdatumbyhash

But it only accepts strings:
https://github.com/mlabs-haskell/ogmios-datum-cache/blob/b6bba2a03f4ab395787070eeebba2fadfa2fcabc/src/Api/WebSocket/Types.hs#L16