### PR TITLE
Fix doc/implementation inconsistency related to JSON-WSP

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,1 +1,3 @@
 packages: ./ogmios-datum-cache.cabal
+
+tests: true

--- a/ogmios-datum-cache.cabal
+++ b/ogmios-datum-cache.cabal
@@ -53,6 +53,9 @@ library
   exposed-modules:
     Api
     Api.Handler
+    Api.WebSocket
+    Api.WebSocket.Json
+    Api.WebSocket.Types
     App
     App.Env
     Block.Fetch
@@ -62,9 +65,6 @@ library
   other-modules:
     Api.Error
     Api.Types
-    Api.WebSocket
-    Api.WebSocket.Json
-    Api.WebSocket.Types
     Block.Filter
     Block.Types
     PlutusData
@@ -125,3 +125,22 @@ executable ogmios-datum-cache
     , wai-cors
     , wai-logger
     , warp
+
+test-suite ogmios-datum-cache-test
+  import:         common-language
+  import:         common-configs
+  type:           exitcode-stdio-1.0
+  hs-source-dirs: test
+  main-is:        Spec.hs
+  other-modules:  Spec.Api.WebSocket.Types
+  ghc-options:
+    -Wall -Wcompat -Wincomplete-uni-patterns
+    -Wincomplete-record-updates -Wredundant-constraints
+    -Wmissing-export-lists -Wmissing-deriving-strategies -Werror -O2
+    -Wunused-packages
+
+  build-depends:
+    , aeson
+    , base
+    , hspec
+    , ogmios-datum-cache

--- a/src/Api/WebSocket.hs
+++ b/src/Api/WebSocket.hs
@@ -55,8 +55,8 @@ import Database qualified
 
 type WSResponse =
   Either
-    (Maybe Text -> JsonWspFault)
-    (Maybe Text -> JsonWspResponse)
+    (Maybe Aeson.Value -> JsonWspFault)
+    (Maybe Aeson.Value -> JsonWspResponse)
 
 getDatumByHash ::
   Text ->

--- a/src/Api/WebSocket/Json.hs
+++ b/src/Api/WebSocket/Json.hs
@@ -36,7 +36,7 @@ import PlutusData qualified
 data JsonWspResponse = JsonWspResponse
   { methodname :: Text
   , result :: Aeson.Value
-  , reflection :: Maybe Text
+  , reflection :: Maybe Aeson.Value
   }
   deriving stock (Generic)
 
@@ -55,7 +55,7 @@ data JsonWspFault = JsonWspFault
   { methodname :: Text
   , faultCode :: Text
   , faultString :: Text
-  , reflection :: Maybe Text
+  , reflection :: Maybe Aeson.Value
   }
   deriving stock (Generic)
 
@@ -74,7 +74,7 @@ instance ToJSON JsonWspFault where
       , "reflection" .= reflection
       ]
 
-mkGetDatumByHashResponse :: Maybe PlutusData.Data -> Maybe Text -> JsonWspResponse
+mkGetDatumByHashResponse :: Maybe PlutusData.Data -> Maybe Aeson.Value -> JsonWspResponse
 mkGetDatumByHashResponse = \case
   Just datumValue ->
     JsonWspResponse "GetDatumByHash" (object ["DatumFound" .= value])
@@ -83,11 +83,11 @@ mkGetDatumByHashResponse = \case
   Nothing ->
     JsonWspResponse "GetDatumByHash" (object ["DatumNotFound" .= Null])
 
-mkGetDatumByHashFault :: Text -> Maybe Text -> JsonWspFault
+mkGetDatumByHashFault :: Text -> Maybe Aeson.Value -> JsonWspFault
 mkGetDatumByHashFault =
   JsonWspFault "GetDatumByHash" "client"
 
-mkGetDatumsByHashesResponse :: Maybe [Aeson.Value] -> Maybe Text -> JsonWspResponse
+mkGetDatumsByHashesResponse :: Maybe [Aeson.Value] -> Maybe Aeson.Value -> JsonWspResponse
 mkGetDatumsByHashesResponse = \case
   Just datumsWithValues ->
     JsonWspResponse "GetDatumsByHashes" (object ["DatumsFound" .= value])
@@ -96,32 +96,32 @@ mkGetDatumsByHashesResponse = \case
   Nothing ->
     JsonWspResponse "GetDatumsByHashes" (object ["DatumsNotFound" .= Null])
 
-mkGetDatumsByHashesFault :: Text -> Maybe Text -> JsonWspFault
+mkGetDatumsByHashesFault :: Text -> Maybe Aeson.Value -> JsonWspFault
 mkGetDatumsByHashesFault =
   JsonWspFault "GetDatumsByHashes" "client"
 
-mkGetBlockResponse :: BlockInfo -> Maybe Text -> JsonWspResponse
+mkGetBlockResponse :: BlockInfo -> Maybe Aeson.Value -> JsonWspResponse
 mkGetBlockResponse block = JsonWspResponse "GetBlock" (object ["block" .= block])
 
-mkGetBlockFault :: Maybe Text -> JsonWspFault
+mkGetBlockFault :: Maybe Aeson.Value -> JsonWspFault
 mkGetBlockFault = JsonWspFault "GetBlock" "notFound" ""
 
-mkStartFetchBlocksResponse :: Maybe Text -> JsonWspResponse
+mkStartFetchBlocksResponse :: Maybe Aeson.Value -> JsonWspResponse
 mkStartFetchBlocksResponse =
   JsonWspResponse "StartFetchBlocks" (object ["StartedBlockFetcher" .= Bool True])
 
-mkStartFetchBlocksFault :: Text -> Maybe Text -> JsonWspFault
+mkStartFetchBlocksFault :: Text -> Maybe Aeson.Value -> JsonWspFault
 mkStartFetchBlocksFault =
   JsonWspFault "StartFetchBlocks" "client"
 
-mkCancelFetchBlocksResponse :: Maybe Text -> JsonWspResponse
+mkCancelFetchBlocksResponse :: Maybe Aeson.Value -> JsonWspResponse
 mkCancelFetchBlocksResponse =
   JsonWspResponse "CancelFetchBlocks" (object ["StoppedBlockFetcher" .= Bool True])
 
-mkCancelFetchBlocksFault :: Text -> Maybe Text -> JsonWspFault
+mkCancelFetchBlocksFault :: Text -> Maybe Aeson.Value -> JsonWspFault
 mkCancelFetchBlocksFault =
   JsonWspFault "CancelFetchBlocks" "client"
 
-mkHealthcheckResponse :: Maybe Text -> JsonWspResponse
+mkHealthcheckResponse :: Maybe Aeson.Value -> JsonWspResponse
 mkHealthcheckResponse =
   JsonWspResponse "GetHealthcheck" (object [])

--- a/src/Api/WebSocket/Types.hs
+++ b/src/Api/WebSocket/Types.hs
@@ -5,6 +5,7 @@ module Api.WebSocket.Types (
 ) where
 
 import Data.Aeson (FromJSON, ToJSON, parseJSON, withObject, (.:), (.:?))
+import Data.Aeson qualified as Aeson
 import Data.Int (Int64)
 import Data.Text (Text)
 import GHC.Generics (Generic)
@@ -13,7 +14,7 @@ import Block.Filter (DatumFilter)
 import PlutusData qualified
 
 data JsonWspRequest = JsonWspRequest
-  { mirror :: Maybe Text
+  { mirror :: Maybe Aeson.Value
   , method :: Method
   }
   deriving stock (Generic)

--- a/src/Api/WebSocket/Types.hs
+++ b/src/Api/WebSocket/Types.hs
@@ -17,7 +17,7 @@ data JsonWspRequest = JsonWspRequest
   { mirror :: Maybe Aeson.Value
   , method :: Method
   }
-  deriving stock (Generic)
+  deriving stock (Generic, Show, Eq)
 
 instance FromJSON JsonWspRequest where
   parseJSON = withObject "GetDatumByHash" $ \o ->
@@ -54,7 +54,7 @@ data Method
   | StartFetchBlocks Int64 Text (Maybe DatumFilter)
   | CancelFetchBlocks
   | GetHealthcheck
-  deriving stock (Show)
+  deriving stock (Show, Eq)
 
 data GetDatumsByHashesDatum = GetDatumsByHashesDatum
   { hash :: Text

--- a/src/Block/Filter.hs
+++ b/src/Block/Filter.hs
@@ -14,7 +14,7 @@ data DatumFilter
   | AllFilter [DatumFilter]
   | DatumHashFilter Text
   | AddressFilter Text
-  deriving stock (Show)
+  deriving stock (Show, Eq)
 
 -- | Filter that accepts all datums
 defaultDatumFilter :: DatumFilter

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,0 +1,8 @@
+module Main (main) where
+
+import Spec.Api.WebSocket.Types qualified
+import Test.Hspec (hspec)
+
+main :: IO ()
+main = hspec $ do
+  Spec.Api.WebSocket.Types.spec

--- a/test/Spec/Api/WebSocket/Types.hs
+++ b/test/Spec/Api/WebSocket/Types.hs
@@ -1,0 +1,21 @@
+module Spec.Api.WebSocket.Types (spec) where
+
+import Api.WebSocket.Types (
+  JsonWspRequest (JsonWspRequest),
+  Method (CancelFetchBlocks),
+ )
+import Data.Aeson (decode)
+import Test.Hspec (Spec, describe, it, shouldBe)
+
+spec :: Spec
+spec = do
+  describe "Api.WebSocket.Types" $ do
+    describe "decode JsonWspRequest with mirror argument" $ do
+      it "mirror is a text" $ do
+        decode "{\"methodname\":\"CancelFetchBlocks\", \"mirror\": \"Text\"}"
+          `shouldBe` Just
+            (JsonWspRequest (Just "Text") CancelFetchBlocks)
+      it "mirrot is an object " $ do
+        decode "{\"methodname\":\"CancelFetchBlocks\", \"mirror\": {\"field\": \"Text\"}}"
+          `shouldBe` Just
+            (JsonWspRequest (decode "{\"field\": \"Text\"}") CancelFetchBlocks)


### PR DESCRIPTION
Context:
- https://github.com/mlabs-haskell/ogmios-datum-cache/pull/37

> The readme suggests that `mirror` accepts arbitrary JSON
> https://github.com/mlabs-haskell/ogmios-datum-cache#getdatumbyhash
> 
> But it only accepts strings:
> https://github.com/mlabs-haskell/ogmios-datum-cache/blob/b6bba2a03f4ab395787070eeebba2fadfa2fcabc/src/Api/WebSocket/Types.hs#L16
