### PR TITLE
Fix error output on config read

### DIFF
--- a/ogmios-datum-cache.cabal
+++ b/ogmios-datum-cache.cabal
@@ -95,6 +95,7 @@ library
     , servant-websockets
     , text
     , tomland
+    , tostring
     , transformers
     , unliftio
     , unliftio-core


### PR DESCRIPTION
Previously:
- if the config file has an error in the fetcher -- it will be ignored and the fetcher set to nothing

Current:
- if the config file has an error in fetcher -- fail
- optional fetcher config prohibit

Also:
- pretty error output
