### PR TITLE
Datum decode error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add `--from-tip` option to cache from current tip.
 - Add `--from-origin` option to cache datums of all blocks.
 - Add `--log-level` option to enable control of logging.
-- Add support for Vasil hardfork (require ogmios `>= 5.5.0`).
+- Add support for Vasil hardfork (require ogmios `>= 5.5.0`). To work with ogmios `< 5.5.0` should pass `--old-ogmios`.
 - Add `GET /healthcheck` endpoint.
 - Add `GetHealthcheck` WebSocket method.
 - Add `GET /tx/<txId>` endpoint.

--- a/README.md
+++ b/README.md
@@ -1012,6 +1012,7 @@ Available options:
   --log-level LOG_LEVEL    One of [debug | info | warn | error], every level is
                            more restrictive than the previous level. By default
                            set to info
+  --old-ogmios             required if ogmios < 5.5.0
   -h,--help                Show this help text
 ```
 

--- a/src/Api/Handler.hs
+++ b/src/Api/Handler.hs
@@ -75,9 +75,12 @@ datumServiceHandlers =
 
     catchDatabaseError r = do
       case r of
-        Left (DatabaseErrorDecodeError e) ->
+        Left (DatabaseErrorDecodeError value err) ->
           throwJsonError err500 $
-            JsonError $ Text.pack $ "Decoding error: " <> show e
+            JsonError $
+              "Decoding error: " <> Text.pack (show value)
+                <> " error: "
+                <> Text.pack (show err)
         Left DatabaseErrorNotFound ->
           throwM err404
         Right x -> pure x

--- a/src/Api/WebSocket.hs
+++ b/src/Api/WebSocket.hs
@@ -60,10 +60,12 @@ getDatumByHash ::
 getDatumByHash hash = do
   res <- Database.getDatumByHash hash
   pure $ case res of
-    Left (DatabaseErrorDecodeError faulty) ->
+    Left (DatabaseErrorDecodeError faulty err) ->
       Left $
         mkGetDatumByHashFault $
-          "Error deserializing plutus Data in: " <> Text.pack (show faulty)
+          "Error deserializing datum plutus Data in: " <> Text.pack (show faulty)
+            <> " error: "
+            <> Text.pack (show err)
     Left DatabaseErrorNotFound ->
       Right $ mkGetDatumByHashResponse Nothing
     Right datum ->
@@ -75,10 +77,12 @@ getDatumsByHashes ::
 getDatumsByHashes hashes = do
   res <- Database.getDatumsByHashes hashes
   pure $ case res of
-    Left (DatabaseErrorDecodeError faulty) -> do
+    Left (DatabaseErrorDecodeError faulty err) -> do
       let resp =
             mkGetDatumsByHashesFault $
-              "Error deserializing plutus Data in: " <> Text.pack (show faulty)
+              "Error deserializing datums plutus Data in: " <> Text.pack (show faulty)
+                <> " error: "
+                <> Text.pack (show err)
       Left resp
     Left DatabaseErrorNotFound ->
       Right $ mkGetDatumsByHashesResponse Nothing
@@ -94,10 +98,12 @@ getTxByHash ::
 getTxByHash txId = do
   res <- Database.getTxByHash txId
   pure $ case res of
-    Left (DatabaseErrorDecodeError faulty) ->
+    Left (DatabaseErrorDecodeError faulty err) ->
       Left $
         mkGetTxByHashResponseFault $
-          "Error deserializing data from db: " <> Text.pack (show faulty)
+          "Error deserializing tx data from db: " <> Text.pack (show faulty)
+            <> " error: "
+            <> Text.pack (show err)
     Left DatabaseErrorNotFound ->
       Right $ mkGetTxByHashResponse Nothing
     Right datum ->

--- a/src/App.hs
+++ b/src/App.hs
@@ -6,6 +6,8 @@ import Control.Monad.Except (ExceptT (ExceptT), MonadIO)
 import Control.Monad.Logger (LogLevel, LoggingT, filterLogger, runStdoutLoggingT)
 import Control.Monad.Reader (runReaderT)
 import Data.Aeson (eitherDecode)
+import Data.ByteString.Base16 qualified as Base16
+import Data.ByteString.Base64 qualified as Base64
 import Data.Default (def)
 import Data.Maybe (fromMaybe)
 import Hasql.Connection qualified as Hasql
@@ -94,6 +96,7 @@ bootstrapEnvFromConfig cfg = do
         firstBlock
         datumFilter
         cfg.cfgFetcher.cfgFetcherQueueSize
+        (if cfg.cfgOldOgmios then Base64.decodeBase64 else Base16.decodeBase16)
         logFilter
     pure $
       Env

--- a/src/Database.hs
+++ b/src/Database.hs
@@ -12,7 +12,7 @@ module Database (
   getTxByHash,
 ) where
 
-import Codec.Serialise (deserialiseOrFail)
+import Codec.Serialise (DeserialiseFailure, deserialiseOrFail)
 import Control.Monad (void)
 import Control.Monad.IO.Class (MonadIO, liftIO)
 import Control.Monad.Logger (MonadLogger, logErrorNS, logInfoNS)
@@ -240,14 +240,14 @@ getLastBlock dbConnection = do
       pure Nothing
 
 data DatabaseError
-  = DatabaseErrorDecodeError [ByteString]
+  = DatabaseErrorDecodeError [ByteString] DeserialiseFailure
   | DatabaseErrorNotFound
 
 toPlutusData :: Datum -> Either DatabaseError PlutusData.Data
 toPlutusData datum =
   let res = deserialiseOrFail @PlutusData.Data (BSL.fromStrict $ value datum)
    in case res of
-        Left _ -> Left $ DatabaseErrorDecodeError [value datum]
+        Left err -> Left $ DatabaseErrorDecodeError [value datum] err
         Right x -> pure x
 
 toPlutusDataMany ::
@@ -265,10 +265,11 @@ toPlutusDataMany datums =
       correct = Vector.mapMaybe (\(datum, data') -> (hash datum,) <$> rightToMaybe data') res
       faulty =
         Vector.toList $
-          Vector.mapMaybe (fmap fst . (\(datum, data') -> (value datum,) <$> leftToMaybe data')) res
-   in if null faulty
-        then pure correct
-        else Left $ DatabaseErrorDecodeError faulty
+          Vector.mapMaybe ((\(datum, data') -> (\err -> DatabaseErrorDecodeError [value datum] err) <$> leftToMaybe data')) res
+   in case faulty of
+        [] -> pure correct
+        -- TODO: return list of all errors
+        (e : _) -> Left e
 
 getDatumByHash ::
   (MonadIO m, MonadReader r m, Has Connection r) =>

--- a/src/Parameters.hs
+++ b/src/Parameters.hs
@@ -67,6 +67,8 @@ data Config = Config
   , cfgOgmiosPort :: Int
   , cfgFetcher :: BlockFetcherConfig
   , cfgLogLevel :: LogLevel
+  , -- | Should be true if ogmios < 5.5.0 (force to use Base64 encoding for datums)
+    cfgOldOgmios :: Bool
   }
   deriving stock (Show, Eq)
 
@@ -234,6 +236,10 @@ argParser =
       )
     <*> parseBlockFetcher
     <*> parseLogLevel
+    <*> switch
+      ( long "old-ogmios"
+          <> help "required if ogmios < 5.5.0"
+      )
 
 parserInfo :: ParserInfo Config
 parserInfo =
@@ -254,6 +260,7 @@ configAsCLIOptions Config {..} =
         Origin -> ["--from-origin"]
         Tip -> ["--from-tip"]
       useLatesString = ["--use-latest" | cfgFetcher.cfgFetcherUseLatest]
+      oldOgmiosString = ["--old-ogmios" | cfgOldOgmios]
       logLevel =
         case cfgLogLevel of
           LevelInfo -> ["--log-level=info"]
@@ -264,6 +271,7 @@ configAsCLIOptions Config {..} =
 
       mostParams =
         useLatesString
+          <> oldOgmiosString
           <> blockOptions
           <> logLevel
           <> [ command "queue-size" cfgFetcher.cfgFetcherQueueSize

--- a/test/Spec/Parameters.hs
+++ b/test/Spec/Parameters.hs
@@ -22,6 +22,7 @@ import Parameters (
     cfgLogLevel,
     cfgOgmiosAddress,
     cfgOgmiosPort,
+    cfgOldOgmios,
     cfgServerControlApiToken,
     cfgServerPort
   ),
@@ -100,6 +101,7 @@ example =
           , cfgFetcherQueueSize = 64
           }
     , cfgLogLevel = LevelWarn
+    , cfgOldOgmios = False
     }
 
 parseParams :: [String] -> Either String Config


### PR DESCRIPTION
Looks like (from Calum Sieppert):

> There seems to be one utxo/datum that ODC is unable to handle, I'm getting the following error when listing NFTs and fetching the datums:
> message: {"reflection":"GetDatumsByHashes-l5bluj1k","methodname":"GetDatumsByHashes","version":"1.0","fault":{"string":"Error deserializing plutus Data in: [\"w\\206\\253\\245\\254|\\213\\205_\\225\\183\\249\\217\\253\\245\\237\\174\\181w\\190Zs\\141\\154o\\174\\154\\215\\167\\188\\DEL\\189\\&7\\217\\237\\159\\235\\151\\218sw\\218oG\\219\\211f\\183\\209\\190|\\219M\\221\\211\\207{y\\189\\SUB\\247\\151\\159\\229\\167|\\223]^\\215\\142t\\233\\237ts\\167\\221\\247f\\218w\\182\\252\\237\\253\\219\\211n|\\245\\222to\\167\\184\\DEL}\\RS}\\231\\223\"]","code":"client"},"servicename":"ogmios-datum-cache","type":"jsonwsp/fault"}

Problem: ogmios before 5.5.0 use Base64, 5.5.0+ - Base16 for encoding datums. So we use the following hack:
`Base64.decodeBase64 bs <> Base16.decodeBase16 bs`, which works most of the time but not always.

In this PR:
- use Base16 encoding for datums
- add CLI flag `--old-ogmios`, which force to use Base64 if ogmios < 5.5.0