### PR TITLE
Override --use-latest if --block-slot is later

### DIFF
--- a/README.md
+++ b/README.md
@@ -1004,9 +1004,9 @@ Available options:
   --from-tip               Start block fetcher from chain tip
   --block-filter FILTER    Filter.
   --use-latest             defines if block fetcher, if started automatically,
-                           should start from last block that was proccessed
-                           rather than from block defined with --block-slot and
-                           --block-hash.
+                           should start from the last block that was proccessed
+                           if later than the block defined with
+                           --block-slot/--from-origin/--from-tip
   --queue-size NATURAL     Defines size of queue of prefetched blocks ready to
                            be processed, default=64.
   --log-level LOG_LEVEL    One of [debug | info | warn | error], every level is

--- a/ogmios-datum-cache.cabal
+++ b/ogmios-datum-cache.cabal
@@ -98,6 +98,7 @@ library
     , QuickCheck
     , record-dot-preprocessor
     , record-hasfield
+    , safe
     , serialise
     , servant
     , servant-server

--- a/src/Block/Types.hs
+++ b/src/Block/Types.hs
@@ -62,11 +62,20 @@ instance FromJSON StartingBlock where
         <*> v .: "blockId"
   parseJSON invalid = prependFailure "parsing StartingBlock failed" $ unexpected invalid
 
+instance Ord StartingBlock where
+  compare Origin Origin = EQ
+  compare Origin _ = LT
+  compare _ Origin = GT
+  compare Tip Tip = EQ
+  compare Tip _ = GT
+  compare _ Tip = LT
+  compare (StartingBlock lBlock) (StartingBlock rBlock) = compare lBlock rBlock
+
 data BlockInfo = BlockInfo
   { blockSlot :: Int64
   , blockId :: Text
   }
-  deriving stock (Generic, Show, Eq)
+  deriving stock (Generic, Show, Eq, Ord)
   deriving anyclass (ToJSON, FromJSON)
 
 type OgmiosMirror = Int

--- a/src/Parameters.hs
+++ b/src/Parameters.hs
@@ -131,9 +131,9 @@ parseBlockFetcher =
     <*> switch
       ( long "use-latest"
           <> help
-            "defines if block fetcher, if started automatically, should \
-            \start from last block that was proccessed rather than from \
-            \block defined with --block-slot and --block-hash."
+            "defines if block fetcher, if started automatically, should start \
+            \from the last block that was proccessed if later than the block \
+            \defined with --block-slot/--from-origin/--from-tip"
       )
     <*> option
       auto


### PR DESCRIPTION
Fixes https://github.com/Plutonomicon/cardano-transaction-lib/issues/714 (hopefully)

We realise the current behaviour was decided in https://github.com/mlabs-haskell/ogmios-datum-cache/issues/91, but we'd ideally like to use the same configuration for both development and production