### PR TITLE
Change Database.getDatumsByHashes type

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,8 @@ usage:
 	@echo "  format_check_all    -- Check haskell files, nix files and cabal files"
 	@echo "  lint                -- Check the sources with hlint"
 	@echo "  refactor            -- Automatically apply hlint refactors, with prompt"
+	@echo "  watch               -- Track files and run 'make build' on change"
+
 
 ## Project
 
@@ -88,6 +90,9 @@ refactor: requires_nix_shell
 	for src in $(PROJECT_SOURCES) ; do \
 		hlint $(HLINT_EXTS) --refactor --refactor-options='-i -s' $$src ;\
 	done
+
+watch: requires_nix_shell ogmios-datum-cache.cabal
+	while sleep 1; do find ogmios-datum-cache.cabal src test | entr -cd make build; done
 
 # Target to use as dependency to fail if not inside nix-shell
 requires_nix_shell:

--- a/ogmios-datum-cache.cabal
+++ b/ogmios-datum-cache.cabal
@@ -70,6 +70,7 @@ library
     Block.Types.Babbage
     Block.Types.Byron
     Database
+    DataHash
     Parameters
 
   other-modules:

--- a/src/Api/Handler.hs
+++ b/src/Api/Handler.hs
@@ -92,8 +92,8 @@ datumServiceHandlers =
       datums <- Database.getDatumsByHashes hashes >>= catchDatabaseError
       let (_, rightDatums) = Map.mapEither id datums
       pure $
-        GetDatumsByHashesResponse $
-          ((uncurry GetDatumsByHashesDatum) <$> (Vector.fromList . Map.toList) rightDatums)
+        GetDatumsByHashesResponse
+          (uncurry GetDatumsByHashesDatum <$> (Vector.fromList . Map.toList) rightDatums)
 
     getTx :: Text -> App Aeson.Value
     getTx txId = do

--- a/src/Api/Handler.hs
+++ b/src/Api/Handler.hs
@@ -30,7 +30,15 @@ import Api (
   WebSocketApi (WebSocketApi, websocketApi),
  )
 import Api.Error (JsonError (JsonError), throwJsonError)
-import Api.Types (ControlApiAuthData (ControlApiAuthData), GetDatumByHashResponse (GetDatumByHashResponse), GetDatumsByHashesDatum (GetDatumsByHashesDatum), GetDatumsByHashesRequest (GetDatumsByHashesRequest), GetDatumsByHashesResponse (GetDatumsByHashesResponse), SetDatumFilterRequest (SetDatumFilterRequest), SetStartingBlockRequest (SetStartingBlockRequest))
+import Api.Types (
+  ControlApiAuthData (ControlApiAuthData),
+  GetDatumByHashResponse (GetDatumByHashResponse),
+  GetDatumsByHashesDatum (GetDatumsByHashesDatum),
+  GetDatumsByHashesRequest (GetDatumsByHashesRequest),
+  GetDatumsByHashesResponse (GetDatumsByHashesResponse),
+  SetDatumFilterRequest (SetDatumFilterRequest),
+  SetStartingBlockRequest (SetStartingBlockRequest),
+ )
 import Api.WebSocket (websocketServer)
 import App.Env (ControlApiToken (ControlApiToken), Env (Env, envControlApiToken))
 import App.Types (App)

--- a/src/Api/Types.hs
+++ b/src/Api/Types.hs
@@ -6,6 +6,7 @@ module Api.Types (
   SetStartingBlockRequest (..),
   SetDatumFilterRequest (..),
   ControlApiAuthData (..),
+  DataHash (..),
 ) where
 
 import Data.Aeson (FromJSON, ToJSON)
@@ -17,18 +18,23 @@ import Block.Filter (DatumFilter)
 import Block.Types (StartingBlock)
 import PlutusData qualified
 
+newtype DataHash = DataHash {dataHash :: Text}
+  deriving stock (Generic, Show, Eq)
+  deriving anyclass (ToJSON)
+  deriving anyclass (FromJSON)
+
 newtype GetDatumByHashResponse = GetDatumByHashResponse PlutusData.Data
   deriving stock (Generic)
   deriving anyclass (ToJSON)
 
 newtype GetDatumsByHashesRequest = GetDatumsByHashesRequest
-  { hashes :: [Text]
+  { hashes :: [DataHash]
   }
   deriving stock (Generic)
   deriving anyclass (FromJSON)
 
 data GetDatumsByHashesDatum = GetDatumsByHashesDatum
-  { hash :: Text
+  { hash :: DataHash
   , value :: PlutusData.Data
   }
   deriving stock (Generic)
@@ -39,7 +45,6 @@ newtype GetDatumsByHashesResponse = GetDatumsByHashesResponse
   }
   deriving stock (Generic)
   deriving anyclass (ToJSON)
-
 newtype SetStartingBlockRequest = SetStartingBlockRequest
   { startingBlock :: StartingBlock
   }

--- a/src/Api/Types.hs
+++ b/src/Api/Types.hs
@@ -6,23 +6,16 @@ module Api.Types (
   SetStartingBlockRequest (..),
   SetDatumFilterRequest (..),
   ControlApiAuthData (..),
-  DataHash (..),
 ) where
 
 import Data.Aeson (FromJSON, ToJSON)
-import Data.Text (Text)
 import Data.Vector (Vector)
 import Servant.API.Generic (Generic)
 
 import Block.Filter (DatumFilter)
 import Block.Types (StartingBlock)
+import DataHash (DataHash)
 import PlutusData qualified
-
-newtype DataHash = DataHash {dataHash :: Text}
-  deriving stock (Generic, Show, Eq)
-  deriving newtype (Ord)
-  deriving anyclass (ToJSON)
-  deriving anyclass (FromJSON)
 
 newtype GetDatumByHashResponse = GetDatumByHashResponse PlutusData.Data
   deriving stock (Generic)

--- a/src/Api/Types.hs
+++ b/src/Api/Types.hs
@@ -20,6 +20,7 @@ import PlutusData qualified
 
 newtype DataHash = DataHash {dataHash :: Text}
   deriving stock (Generic, Show, Eq)
+  deriving newtype (Ord)
   deriving anyclass (ToJSON)
   deriving anyclass (FromJSON)
 

--- a/src/Api/WebSocket.hs
+++ b/src/Api/WebSocket.hs
@@ -10,6 +10,7 @@ import Data.Text qualified as Text
 import Data.Vector qualified as Vector
 import Network.WebSockets qualified as WebSockets
 
+import Api.Types (DataHash)
 import Api.WebSocket.Json (
   JsonWspFault (JsonWspFault),
   JsonWspResponse,
@@ -55,7 +56,7 @@ type WSResponse =
     (Maybe Aeson.Value -> JsonWspResponse)
 
 getDatumByHash ::
-  Text ->
+  DataHash ->
   App WSResponse
 getDatumByHash hash = do
   res <- Database.getDatumByHash hash
@@ -72,7 +73,7 @@ getDatumByHash hash = do
       Right $ mkGetDatumByHashResponse $ Just datum
 
 getDatumsByHashes ::
-  [Text] ->
+  [DataHash] ->
   App WSResponse
 getDatumsByHashes hashes = do
   res <- Database.getDatumsByHashes hashes

--- a/src/Api/WebSocket.hs
+++ b/src/Api/WebSocket.hs
@@ -10,7 +10,6 @@ import Data.Text qualified as Text
 import Data.Vector qualified as Vector
 import Network.WebSockets qualified as WebSockets
 
-import Api.Types (DataHash)
 import Api.WebSocket.Json (
   JsonWspFault (JsonWspFault),
   JsonWspResponse,
@@ -45,6 +44,7 @@ import App.Types (App)
 import Block.Fetch (changeDatumFilter, changeStartingBlock)
 import Block.Filter (DatumFilter)
 import Block.Types (StartingBlock)
+import DataHash (DataHash)
 import Database (
   DatabaseError (DatabaseErrorDecodeError, DatabaseErrorNotFound),
  )

--- a/src/Api/WebSocket.hs
+++ b/src/Api/WebSocket.hs
@@ -91,15 +91,11 @@ getDatumsByHashes hashes = do
       Right $ mkGetDatumsByHashesResponse Nothing
     Right datumsOrErrors ->
       let rightDatums :: [(DataHash, PlutusData.Data)]
-          (faultDatums, rightDatums) =
+          (_, rightDatums) =
             bimap Map.toList Map.toList $ Map.mapEither id datumsOrErrors
           datums' =
             Aeson.toJSON <$> (uncurry GetDatumsByHashesDatum <$> rightDatums)
-       in case faultDatums of
-            -- TODO : should we return both of them or at least log the
-            -- wrong datums?
-            [] -> Right $ mkGetDatumsByHashesResponse (Just datums')
-            _ -> Right $ mkGetDatumsByHashesResponse (Just datums')
+       in Right $ mkGetDatumsByHashesResponse (Just datums')
 
 getTxByHash ::
   Text ->

--- a/src/Api/WebSocket/Types.hs
+++ b/src/Api/WebSocket/Types.hs
@@ -66,7 +66,7 @@ data Method
   deriving stock (Show, Eq)
 
 data GetDatumsByHashesDatum = GetDatumsByHashesDatum
-  { hash :: Text
+  { hash :: DataHash
   , value :: PlutusData.Data
   }
   deriving stock (Generic)

--- a/src/Api/WebSocket/Types.hs
+++ b/src/Api/WebSocket/Types.hs
@@ -9,10 +9,10 @@ import Data.Aeson qualified as Aeson
 import Data.Text (Text)
 import GHC.Generics (Generic)
 
-import Api.Types (DataHash (DataHash))
 import App.Env (ControlApiToken (ControlApiToken))
 import Block.Filter (DatumFilter)
 import Block.Types (StartingBlock)
+import DataHash (DataHash (DataHash))
 import PlutusData qualified
 
 data JsonWspRequest = JsonWspRequest

--- a/src/Api/WebSocket/Types.hs
+++ b/src/Api/WebSocket/Types.hs
@@ -9,6 +9,7 @@ import Data.Aeson qualified as Aeson
 import Data.Text (Text)
 import GHC.Generics (Generic)
 
+import Api.Types (DataHash (DataHash))
 import App.Env (ControlApiToken (ControlApiToken))
 import Block.Filter (DatumFilter)
 import Block.Types (StartingBlock)
@@ -30,11 +31,11 @@ instance FromJSON JsonWspRequest where
           "GetDatumByHash" -> do
             args <- o .: "args"
             hash <- args .: "hash"
-            pure $ GetDatumByHash hash
+            pure $ GetDatumByHash (DataHash hash)
           "GetDatumsByHashes" -> do
             args <- o .: "args"
             hashes <- args .: "hashes"
-            pure $ GetDatumsByHashes hashes
+            pure $ GetDatumsByHashes (DataHash <$> hashes)
           "GetTxByHash" -> do
             args <- o .: "args"
             hash <- args .: "hash"
@@ -55,8 +56,8 @@ instance FromJSON JsonWspRequest where
           _ -> fail "Unexpected method"
 
 data Method
-  = GetDatumByHash Text
-  | GetDatumsByHashes [Text]
+  = GetDatumByHash DataHash
+  | GetDatumsByHashes [DataHash]
   | GetTxByHash Text
   | GetBlock
   | GetHealthcheck

--- a/src/Block/Fetch.hs
+++ b/src/Block/Fetch.hs
@@ -39,7 +39,6 @@ import Control.Monad.Reader.Has (Has)
 import Control.Monad.Reader.Has qualified as Has
 import Control.Monad.Trans (liftIO)
 import Data.Aeson qualified as Aeson
-import Data.Bifunctor (first)
 import Data.ByteString qualified as ByteString
 import Data.ByteString.Lazy qualified as ByteStringLazy
 import Data.Map qualified as Map
@@ -363,7 +362,7 @@ saveDatumsFromBlock block = do
   datumFilter <- liftIO $ readMVar env.datumFilterMVar
   let txs = transactionsInBlock block
       getFilteredDatums tx =
-        filter (runDatumFilter datumFilter tx) . (first dataHash <$>) . Map.toList . datumsInTransaction $ tx
+        filter (runDatumFilter datumFilter tx) . Map.toList . datumsInTransaction $ tx
       requestedDatums =
         Map.fromList
           . concatMap getFilteredDatums
@@ -374,7 +373,7 @@ saveDatumsFromBlock block = do
   unless (null failedDecodings) $ do
     logErrorNS "saveDatumsFromBlock" $
       "Error decoding values for datums (Base64 or Base16): "
-        <> Text.intercalate ", " (Map.keys failedDecodings)
+        <> Text.intercalate ", " (dataHash <$> Map.keys failedDecodings)
     pure ()
   let datums_ = Map.toList requestedDatumsWithDecodedValues
   unless (null datums_) $ saveDatums env.dbConn datums_

--- a/src/Block/Fetch.hs
+++ b/src/Block/Fetch.hs
@@ -39,6 +39,7 @@ import Control.Monad.Reader.Has (Has)
 import Control.Monad.Reader.Has qualified as Has
 import Control.Monad.Trans (liftIO)
 import Data.Aeson qualified as Aeson
+import Data.Bifunctor (first)
 import Data.ByteString qualified as ByteString
 import Data.ByteString.Lazy qualified as ByteStringLazy
 import Data.Map qualified as Map
@@ -72,6 +73,7 @@ import Block.Types (
   tipToBlockInfo,
   transactionsInBlock,
  )
+import DataHash (DataHash (dataHash))
 import Database (getLastBlock, saveDatums, saveTxs, updateLastBlock)
 
 data OgmiosInfo = OgmiosInfo
@@ -361,7 +363,7 @@ saveDatumsFromBlock block = do
   datumFilter <- liftIO $ readMVar env.datumFilterMVar
   let txs = transactionsInBlock block
       getFilteredDatums tx =
-        filter (runDatumFilter datumFilter tx) . Map.toList . datumsInTransaction $ tx
+        filter (runDatumFilter datumFilter tx) . (first dataHash <$>) . Map.toList . datumsInTransaction $ tx
       requestedDatums =
         Map.fromList
           . concatMap getFilteredDatums

--- a/src/Block/Fetch.hs
+++ b/src/Block/Fetch.hs
@@ -72,7 +72,7 @@ import Block.Types (
   tipToBlockInfo,
   transactionsInBlock,
  )
-import DataHash (DataHash (dataHash))
+import DataHash (DataHash (unDataHash))
 import Database (getLastBlock, saveDatums, saveTxs, updateLastBlock)
 
 data OgmiosInfo = OgmiosInfo
@@ -373,7 +373,7 @@ saveDatumsFromBlock block = do
   unless (null failedDecodings) $ do
     logErrorNS "saveDatumsFromBlock" $
       "Error decoding values for datums (Base64 or Base16): "
-        <> Text.intercalate ", " (dataHash <$> Map.keys failedDecodings)
+        <> Text.intercalate ", " (unDataHash <$> Map.keys failedDecodings)
     pure ()
   let datums_ = Map.toList requestedDatumsWithDecodedValues
   unless (null datums_) $ saveDatums env.dbConn datums_

--- a/src/Block/Filter.hs
+++ b/src/Block/Filter.hs
@@ -7,6 +7,7 @@ import Data.Text (Text)
 import GHC.Exts (toList)
 
 import Block.Types (SomeTransaction (AlonzoTransaction, BabbageTransaction))
+import DataHash (DataHash (dataHash))
 
 data DatumFilter
   = ConstFilter Bool
@@ -47,13 +48,13 @@ runDatumFilter (DatumHashFilter expectedHash) _ (actualHash, _) =
   expectedHash == actualHash
 runDatumFilter (AddressFilter expectedAddress) (AlonzoTransaction tx') (actualHash, _) =
   let hashes =
-        mapMaybe (.datumHash)
+        mapMaybe (\x -> dataHash <$> x.datumHash)
           . filter (\tx -> tx.address == expectedAddress)
           $ tx'.outputs
    in actualHash `elem` hashes
 runDatumFilter (AddressFilter expectedAddress) (BabbageTransaction tx') (actualHash, _) =
   let hashes =
-        mapMaybe (.datumHash)
+        mapMaybe (\x -> dataHash <$> x.datumHash)
           . filter (\tx -> tx.address == expectedAddress)
           $ tx'.outputs
    in actualHash `elem` hashes

--- a/src/Block/Types.hs
+++ b/src/Block/Types.hs
@@ -40,6 +40,7 @@ import GHC.Generics (Generic)
 import Block.Types.Alonzo qualified as Alonzo
 import Block.Types.Babbage qualified as Babbage
 import Block.Types.Byron qualified as Byron
+import DataHash (DataHash)
 
 data StartingBlock = StartingBlock BlockInfo | Origin | Tip
   deriving stock (Show, Eq)
@@ -261,7 +262,7 @@ instance FromJSON RequestNextResult where
           rollObj
       _ -> fail "Unexpected object key"
 
-datumsInTransaction :: SomeTransaction -> Map Text Text
+datumsInTransaction :: SomeTransaction -> Map DataHash Text
 datumsInTransaction (AlonzoTransaction tx) = Alonzo.datumsInTransaction tx
 datumsInTransaction (BabbageTransaction tx) = Babbage.datumsInTransaction tx
 

--- a/src/Block/Types/Alonzo.hs
+++ b/src/Block/Types/Alonzo.hs
@@ -14,9 +14,11 @@ import Data.Int (Int64)
 import Data.Map (Map)
 import Data.Text (Text)
 
+import DataHash (DataHash)
+
 data TxOut = TxOut
   { address :: Text
-  , datumHash :: Maybe Text
+  , datumHash :: Maybe DataHash
   }
   deriving stock (Eq, Show)
 
@@ -27,7 +29,7 @@ instance FromJSON TxOut where
     pure $ TxOut {..}
 
 data Transaction = Transaction
-  { datums :: Map Text Text
+  { datums :: Map DataHash Text
   , outputs :: [TxOut]
   }
   deriving stock (Eq, Show)
@@ -80,5 +82,5 @@ instance FromJSON Block where
       <*> v .: "header"
       <*> v .: "headerHash"
 
-datumsInTransaction :: Transaction -> Map Text Text
+datumsInTransaction :: Transaction -> Map DataHash Text
 datumsInTransaction tx = tx.datums

--- a/src/DataHash.hs
+++ b/src/DataHash.hs
@@ -4,10 +4,10 @@ import Data.Aeson (FromJSON, FromJSONKey, ToJSON (toJSON))
 import Data.Text qualified as Text
 import Servant.API.Generic (Generic)
 
-newtype DataHash = DataHash {dataHash :: Text.Text}
+newtype DataHash = DataHash {unDataHash :: Text.Text}
   deriving stock (Generic, Show, Eq)
   deriving newtype (Ord, FromJSONKey)
   deriving anyclass (FromJSON)
 
 instance ToJSON DataHash where
-  toJSON = toJSON . dataHash
+  toJSON = toJSON . unDataHash

--- a/src/DataHash.hs
+++ b/src/DataHash.hs
@@ -10,5 +10,4 @@ newtype DataHash = DataHash {dataHash :: Text.Text}
   deriving anyclass (FromJSON)
 
 instance ToJSON DataHash where
-  --toJSON = toJSON . (\x -> Text.pack ("hi " <> Text.unpack (dataHash x)))
   toJSON = toJSON . dataHash

--- a/src/DataHash.hs
+++ b/src/DataHash.hs
@@ -1,11 +1,14 @@
 module DataHash (DataHash (..)) where
 
-import Data.Aeson (FromJSON, ToJSON)
+import Data.Aeson (FromJSON, ToJSON (toJSON))
 import Data.Text qualified as Text
 import Servant.API.Generic (Generic)
 
 newtype DataHash = DataHash {dataHash :: Text.Text}
   deriving stock (Generic, Show, Eq)
   deriving newtype (Ord)
-  deriving anyclass (ToJSON)
   deriving anyclass (FromJSON)
+
+instance ToJSON DataHash where
+  --toJSON = toJSON . (\x -> Text.pack ("hi " <> Text.unpack (dataHash x)))
+  toJSON = toJSON . dataHash

--- a/src/DataHash.hs
+++ b/src/DataHash.hs
@@ -1,0 +1,11 @@
+module DataHash (DataHash (..)) where
+
+import Data.Aeson (FromJSON, ToJSON)
+import Data.Text qualified as Text
+import Servant.API.Generic (Generic)
+
+newtype DataHash = DataHash {dataHash :: Text.Text}
+  deriving stock (Generic, Show, Eq)
+  deriving newtype (Ord)
+  deriving anyclass (ToJSON)
+  deriving anyclass (FromJSON)

--- a/src/DataHash.hs
+++ b/src/DataHash.hs
@@ -1,12 +1,12 @@
 module DataHash (DataHash (..)) where
 
-import Data.Aeson (FromJSON, ToJSON (toJSON))
+import Data.Aeson (FromJSON, FromJSONKey, ToJSON (toJSON))
 import Data.Text qualified as Text
 import Servant.API.Generic (Generic)
 
 newtype DataHash = DataHash {dataHash :: Text.Text}
   deriving stock (Generic, Show, Eq)
-  deriving newtype (Ord)
+  deriving newtype (Ord, FromJSONKey)
   deriving anyclass (FromJSON)
 
 instance ToJSON DataHash where

--- a/src/Database.hs
+++ b/src/Database.hs
@@ -44,7 +44,7 @@ import Block.Types (
  )
 import Block.Types.Alonzo qualified as Alonzo
 import Block.Types.Babbage qualified as Babbage
-import DataHash (DataHash (DataHash, dataHash))
+import DataHash (DataHash (DataHash, unDataHash))
 import PlutusData qualified
 
 data Datum = Datum
@@ -63,7 +63,7 @@ getDatumStatement = Statement sql enc dec True
     sql =
       "SELECT hash, value FROM datums WHERE hash = $1"
     enc =
-      Encoders.param (Encoders.nonNullable (dataHash >$< Encoders.text))
+      Encoders.param (Encoders.nonNullable (unDataHash >$< Encoders.text))
     dec =
       Decoders.singleRow $
         Datum
@@ -85,7 +85,7 @@ getDatumsStatement = Statement sql enc dec True
         Encoders.nonNullable $
           Encoders.array $
             Encoders.dimension foldl' $
-              Encoders.element (Encoders.nonNullable (dataHash >$< Encoders.text))
+              Encoders.element (Encoders.nonNullable (unDataHash >$< Encoders.text))
     dec =
       Decoders.rowVector $
         Datum
@@ -111,7 +111,7 @@ insertDatumsStatement = Statement sql enc dec True
               Encoders.element $
                 Encoders.nonNullable elemEncoder
     enc =
-      (fst >$< encArray (dataHash >$< Encoders.text))
+      (fst >$< encArray (unDataHash >$< Encoders.text))
         <> (snd >$< encArray Encoders.bytea)
 
     dec = Decoders.noResult
@@ -310,7 +310,7 @@ saveDatums ::
 saveDatums dbConnection datums = do
   let (datumHashes, datumValues) = unzip datums
   logInfoNS "saveDatums" $
-    "Inserting datums: " <> Text.intercalate ", " (dataHash <$> datumHashes)
+    "Inserting datums: " <> Text.intercalate ", " (unDataHash <$> datumHashes)
   res <-
     liftIO $
       Session.run (insertDatumsSession datumHashes datumValues) dbConnection

--- a/src/Database.hs
+++ b/src/Database.hs
@@ -287,7 +287,7 @@ getDatumByHash hash = runExceptT $ do
 -- FIXME Don't exit upon a single error and change return type
 -- See: https://github.com/mlabs-haskell/ogmios-datum-cache/issues/112
 getDatumsByHashes ::
-  (MonadIO m, MonadReader r m, Has Connection r, MonadLogger m) =>
+  (MonadIO m, MonadReader r m, Has Connection r) =>
   [DataHash] ->
   m (Either DatabaseError (Map DataHash (Either DatabaseError PlutusData.Data)))
 getDatumsByHashes hashes = runExceptT $ do

--- a/src/Database.hs
+++ b/src/Database.hs
@@ -293,7 +293,6 @@ getDatumsByHashes ::
 getDatumsByHashes hashes = runExceptT $ do
   conn <- ask
   res' <- liftIO (Session.run (getDatumsSession hashes) conn)
-  --  logErrorNS "datums are" $ Text.pack $ show res'
   case res' of
     Left _ -> throwE DatabaseErrorNotFound
     Right datums ->

--- a/src/Database.hs
+++ b/src/Database.hs
@@ -35,7 +35,6 @@ import Hasql.Session (Session)
 import Hasql.Session qualified as Session
 import Hasql.Statement (Statement (Statement))
 
-import Api.Types (DataHash (DataHash, dataHash))
 import Block.Types (
   BlockInfo (BlockInfo),
   SomeRawTransaction (AlonzoRawTransaction, BabbageRawTransaction),
@@ -45,6 +44,7 @@ import Block.Types (
 import Block.Types.Alonzo qualified as Alonzo
 import Block.Types.Babbage qualified as Babbage
 import Data.Bifunctor (bimap)
+import DataHash (DataHash (DataHash, dataHash))
 import PlutusData qualified
 
 data Datum = Datum

--- a/src/Database.hs
+++ b/src/Database.hs
@@ -284,8 +284,6 @@ getDatumByHash hash = runExceptT $ do
     Left _ -> throwE DatabaseErrorNotFound
     Right datum -> except $ toPlutusData datum
 
--- FIXME Don't exit upon a single error and change return type
--- See: https://github.com/mlabs-haskell/ogmios-datum-cache/issues/112
 getDatumsByHashes ::
   (MonadIO m, MonadReader r m, Has Connection r) =>
   [DataHash] ->

--- a/test/Spec/Block/Babbage.hs
+++ b/test/Spec/Block/Babbage.hs
@@ -10,6 +10,7 @@ import Block.Types (
   SomeBlock (BabbageBlock),
  )
 import Block.Types.Babbage qualified as Babbage
+import DataHash (DataHash (DataHash))
 
 example :: RequestNextResult
 example =
@@ -52,8 +53,8 @@ fixedOutputs =
       Nothing
   ]
 
-fixedDatums :: Map.Map Text.Text Text.Text
-fixedDatums = Map.fromList [("property1", "string"), ("property2", "string")]
+fixedDatums :: Map.Map DataHash Text.Text
+fixedDatums = Map.fromList [(DataHash "property1", "string"), (DataHash "property2", "string")]
 
 fixedRawTransactions :: [Babbage.RawTransaction]
 fixedRawTransactions =


### PR DESCRIPTION
solves #112 
- [x] Add `DataHash` newtype with minimal impact 
- [x] rewrite `getDatumsByHashes` to return a `Map` 
- [X] solve compiler errors introduced by the change of `getDatumByHashes`
- [x] Debug solution (in progress)
- [x] Change `Text` types that represent hash to use `DataHash`
- [x] format